### PR TITLE
Disable parallel computing for pbkdf2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## v0.5.1
 
-No source changes, minor version bump due to the addition of license files, which are 
+No source changes, minor version bump due to the addition of license files, which are
 included when packaging a crate.
 
 The license specified in the Cargo manifest is still correct.
@@ -24,7 +24,7 @@ minor version of the crate.
 
 Should be source compatible with v0.4.0, only the crate dependencies have changed.
 
-### Changes 
+### Changes
 
 * Update ring, bitreader, and error-chain [ae9bdfa]
 
@@ -33,7 +33,7 @@ Should be source compatible with v0.4.0, only the crate dependencies have change
 Mostly source compatible with v0.3.0, except for the additional error kind, and guarding
 against invalid entropy lengths being used to create a Mnemonic.
 
-### Changes 
+### Changes
 
 * Add failure test for Mnemonic::from_entropy()  [4be7216]
 * Return error when invalid entropy is used  [becd7b1]
@@ -75,8 +75,8 @@ phrase the next time you use it.
 You should *think very carefully* before storing or using entropy values directly rather than the
 mnemonic string, they are generally not useful except in advanced use cases and cannot be
 used for HD wallet addresses (that's what the Seed is for, which is not the same thing).
- 
-### Changes 
+
+### Changes
 
 * Better documentation
     * Add quick start example to docs in crate root [4e3b097]
@@ -97,7 +97,7 @@ used for HD wallet addresses (that's what the Seed is for, which is not the same
 
 ## v0.2.1
 
-### Changes 
+### Changes
 
 * Update rand crate
 * Update Ring crate
@@ -119,7 +119,7 @@ only internal organization and crate dependencies.
 
 Minor changes to public API, but also removes a panic!() call
 
-### Changes 
+### Changes
 
 * Implement std::error::Error and std:fmt::Display on Bip39Error
 * Use Into<String> for public function arguments

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "tiny-bip39"
-version = "0.6.0"
+version = "0.6.1"
 authors = [ "Stephen Oliver <steve@infincia.com>" ]
 license = "MIT/Apache-2.0"
-homepage = "https://github.com/infincia/bip39-rs/"
-repository = "https://github.com/infincia/bip39-rs/"
+homepage = "https://github.com/maciejhirsz/tiny-bip39/"
+repository = "https://github.com/maciejhirsz/tiny-bip39/"
 readme = "README.md"
 description = "A fork of the bip39 crate with fixes to v0.6. Rust implementation of BIP-0039"
-documentation = "https://docs.rs/bip39"
+documentation = "https://docs.rs/tiny-bip39"
 keywords = ["bip39", "bitcoin", "mnemonic"]
 
 [lib]
@@ -29,12 +29,12 @@ default = ["chinese-simplified", "chinese-traditional", "french", "italian", "ja
 [dependencies]
 failure = "0.1.3"
 # Note: hashbrown is going to be merged into Rust std
-hashbrown = "0.1.7"
+hashbrown = "0.1.8"
 sha2 = "0.8.0"
 hmac = "0.7.0"
-pbkdf2 = { version = "0.3.0", features=["parallel"], default-features = false }
+pbkdf2 = { version = "0.3.0", default-features = false }
 rand = "0.6.5"
-once_cell = { version = "0.1.6", features = [ "parking_lot" ] }
+once_cell = { version = "0.1.8", features = [ "parking_lot" ] }
 
 [dev-dependencies]
 hex = "0.3.2"

--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 This is a fork of the [`bip39`](https://crates.io/crates/bip39) crate with fixes for v0.6.
 
-It will be deprecated once v0.6 of the upstream crate is released.
-
 ## Changes
 
 See the [changelog](./CHANGELOG.md) file, or the Github releases for specific tags.


### PR DESCRIPTION
There is no difference in benches (occasionally it's actually faster without `rayon`), and it complicates builds for Wasm.