### PR TITLE
Fix broken hex formatting.

### DIFF
--- a/src/mnemonic.rs
+++ b/src/mnemonic.rs
@@ -274,7 +274,7 @@ impl fmt::LowerHex for Mnemonic {
         }
 
         for byte in self.entropy() {
-            write!(f, "{:x}", byte)?;
+            write!(f, "{:02x}", byte)?;
         }
 
         Ok(())
@@ -288,7 +288,7 @@ impl fmt::UpperHex for Mnemonic {
         }
 
         for byte in self.entropy() {
-            write!(f, "{:X}", byte)?;
+            write!(f, "{:02X}", byte)?;
         }
 
         Ok(())
@@ -346,13 +346,13 @@ mod test {
 
     #[test]
     fn mnemonic_hex_format() {
-        let entropy = &[0x33, 0xE4, 0x6B, 0xB1, 0x3A, 0x74, 0x6E, 0xA4, 0x1C, 0xDD, 0xE4, 0x5C, 0x90, 0x84, 0x6A, 0x79];
+        let entropy = &[0x03, 0xE4, 0x6B, 0xB1, 0x3A, 0x74, 0x6E, 0xA4, 0x1C, 0xDD, 0xE4, 0x5C, 0x90, 0x84, 0x6A, 0x79];
 
         let mnemonic = Mnemonic::from_entropy(entropy, Language::English).unwrap();
 
-        assert_eq!(format!("{:x}", mnemonic), "33e46bb13a746ea41cdde45c90846a79");
-        assert_eq!(format!("{:X}", mnemonic), "33E46BB13A746EA41CDDE45C90846A79");
-        assert_eq!(format!("{:#x}", mnemonic), "0x33e46bb13a746ea41cdde45c90846a79");
-        assert_eq!(format!("{:#X}", mnemonic), "0x33E46BB13A746EA41CDDE45C90846A79");
+        assert_eq!(format!("{:x}", mnemonic), "03e46bb13a746ea41cdde45c90846a79");
+        assert_eq!(format!("{:X}", mnemonic), "03E46BB13A746EA41CDDE45C90846A79");
+        assert_eq!(format!("{:#x}", mnemonic), "0x03e46bb13a746ea41cdde45c90846a79");
+        assert_eq!(format!("{:#X}", mnemonic), "0x03E46BB13A746EA41CDDE45C90846A79");
     }
 }

--- a/src/seed.rs
+++ b/src/seed.rs
@@ -59,7 +59,7 @@ impl fmt::LowerHex for Seed {
         }
 
         for byte in &self.bytes {
-            write!(f, "{:x}", byte)?;
+            write!(f, "{:02x}", byte)?;
         }
 
         Ok(())
@@ -73,9 +73,28 @@ impl fmt::UpperHex for Seed {
         }
 
         for byte in &self.bytes {
-            write!(f, "{:X}", byte)?;
+            write!(f, "{:02X}", byte)?;
         }
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use language::Language;
+
+    #[test]
+    fn seed_hex_format() {
+        let entropy = &[0x33, 0xE4, 0x6B, 0xB1, 0x3A, 0x74, 0x6E, 0xA4, 0x1C, 0xDD, 0xE4, 0x5C, 0x90, 0x84, 0x6A, 0x79];
+
+        let mnemonic = Mnemonic::from_entropy(entropy, Language::English).unwrap();
+        let seed = Seed::new(&mnemonic, "password");
+
+        assert_eq!(format!("{:x}", seed), "0bde96f14c35a66235478e0c16c152fcaf6301e4d9a81d3febc50879fe7e5438e6a8dd3e39bdf3ab7b12d6b44218710e17d7a2844ee9633fab0e03d9a6c8569b");
+        assert_eq!(format!("{:X}", seed), "0BDE96F14C35A66235478E0C16C152FCAF6301E4D9A81D3FEBC50879FE7E5438E6A8DD3E39BDF3AB7B12D6B44218710E17D7A2844EE9633FAB0E03D9A6C8569B");
+        assert_eq!(format!("{:#x}", seed), "0x0bde96f14c35a66235478e0c16c152fcaf6301e4d9a81d3febc50879fe7e5438e6a8dd3e39bdf3ab7b12d6b44218710e17d7a2844ee9633fab0e03d9a6c8569b");
+        assert_eq!(format!("{:#X}", seed), "0x0BDE96F14C35A66235478E0C16C152FCAF6301E4D9A81D3FEBC50879FE7E5438E6A8DD3E39BDF3AB7B12D6B44218710E17D7A2844EE9633FAB0E03D9A6C8569B");
     }
 }


### PR DESCRIPTION
Every byte should correspond to two hexadecimal characters.  The previous implementation emitted a single character for byte values between 0x00 and 0x0f inclusive.

(I’m not really a fan of including any LowerHex/UpperHex impl whatsoever.  But hey, it’s broken, so I fixed it!)