### PR TITLE
Update dependencies and edition to 2018

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tiny-bip39"
-version = "0.6.2"
+version = "0.7.0"
 authors = [
     "Stephen Oliver <steve@infincia.com>",
     "Maciej Hirsz <hello@maciej.codes",
@@ -12,6 +12,7 @@ readme = "README.md"
 description = "A fork of the bip39 crate with fixes to v0.6. Rust implementation of BIP-0039"
 documentation = "https://docs.rs/tiny-bip39"
 keywords = ["bip39", "bitcoin", "mnemonic"]
+edition = "2018"
 
 [lib]
 name = "bip39"
@@ -31,13 +32,12 @@ default = ["chinese-simplified", "chinese-traditional", "french", "italian", "ja
 
 [dependencies]
 failure = "0.1.3"
-# Note: hashbrown is going to be merged into Rust std
-hashbrown = "0.1.8"
-sha2 = "0.8.0"
-hmac = "0.7.0"
+rustc-hash = "1.0.1"
+sha2 = "0.8.1"
+hmac = "0.7.1"
 pbkdf2 = { version = "0.3.0", default-features = false }
-rand = "0.6.5"
-once_cell = { version = "0.1.8", features = [ "parking_lot" ] }
+rand = "0.7.2"
+once_cell = { version = "1.2.0", features = [ "parking_lot" ] }
 
 [dev-dependencies]
-hex = "0.3.2"
+hex = "0.4.0"

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,4 @@
-use mnemonic_type::MnemonicType;
+use crate::mnemonic_type::MnemonicType;
 
 #[derive(Debug, Fail)]
 pub enum ErrorKind {

--- a/src/language.rs
+++ b/src/language.rs
@@ -1,10 +1,10 @@
-use error::ErrorKind;
 use failure::Error;
-use hashbrown::HashMap;
-use util::{Bits, Bits11};
+use rustc_hash::FxHashMap;
+use crate::error::ErrorKind;
+use crate::util::{Bits, Bits11};
 
 pub struct WordMap {
-    inner: HashMap<&'static str, Bits11>,
+    inner: FxHashMap<&'static str, Bits11>,
 }
 
 pub struct WordList {
@@ -52,46 +52,46 @@ mod lazy {
     }
 
     pub static WORDLIST_ENGLISH: Lazy<WordList> =
-        sync_lazy! { gen_wordlist(include_str!("langs/english.txt")) };
+        Lazy::new(|| gen_wordlist(include_str!("langs/english.txt")));
     #[cfg(feature = "chinese-simplified")]
     pub static WORDLIST_CHINESE_SIMPLIFIED: Lazy<WordList> =
-        sync_lazy! { gen_wordlist(include_str!("langs/chinese_simplified.txt")) };
+        Lazy::new(|| gen_wordlist(include_str!("langs/chinese_simplified.txt")));
     #[cfg(feature = "chinese-traditional")]
     pub static WORDLIST_CHINESE_TRADITIONAL: Lazy<WordList> =
-        sync_lazy! { gen_wordlist(include_str!("langs/chinese_traditional.txt")) };
+        Lazy::new(|| gen_wordlist(include_str!("langs/chinese_traditional.txt")));
     #[cfg(feature = "french")]
     pub static WORDLIST_FRENCH: Lazy<WordList> =
-        sync_lazy! { gen_wordlist(include_str!("langs/french.txt")) };
+        Lazy::new(|| gen_wordlist(include_str!("langs/french.txt")));
     #[cfg(feature = "italian")]
     pub static WORDLIST_ITALIAN: Lazy<WordList> =
-        sync_lazy! { gen_wordlist(include_str!("langs/italian.txt")) };
+        Lazy::new(|| gen_wordlist(include_str!("langs/italian.txt")));
     #[cfg(feature = "japanese")]
     pub static WORDLIST_JAPANESE: Lazy<WordList> =
-        sync_lazy! { gen_wordlist(include_str!("langs/japanese.txt")) };
+        Lazy::new(|| gen_wordlist(include_str!("langs/japanese.txt")));
     #[cfg(feature = "korean")]
     pub static WORDLIST_KOREAN: Lazy<WordList> =
-        sync_lazy! { gen_wordlist(include_str!("langs/korean.txt")) };
+        Lazy::new(|| gen_wordlist(include_str!("langs/korean.txt")));
     #[cfg(feature = "spanish")]
     pub static WORDLIST_SPANISH: Lazy<WordList> =
-        sync_lazy! { gen_wordlist(include_str!("langs/spanish.txt")) };
+        Lazy::new(|| gen_wordlist(include_str!("langs/spanish.txt")));
 
-    pub static WORDMAP_ENGLISH: Lazy<WordMap> = sync_lazy! { gen_wordmap(&WORDLIST_ENGLISH) };
+    pub static WORDMAP_ENGLISH: Lazy<WordMap> = Lazy::new(|| gen_wordmap(&WORDLIST_ENGLISH));
     #[cfg(feature = "chinese-simplified")]
     pub static WORDMAP_CHINESE_SIMPLIFIED: Lazy<WordMap> =
-        sync_lazy! {  gen_wordmap(&WORDLIST_CHINESE_SIMPLIFIED) };
+        Lazy::new(|| gen_wordmap(&WORDLIST_CHINESE_SIMPLIFIED));
     #[cfg(feature = "chinese-traditional")]
     pub static WORDMAP_CHINESE_TRADITIONAL: Lazy<WordMap> =
-        sync_lazy! { gen_wordmap(&WORDLIST_CHINESE_TRADITIONAL) };
+        Lazy::new(|| gen_wordmap(&WORDLIST_CHINESE_TRADITIONAL));
     #[cfg(feature = "french")]
-    pub static WORDMAP_FRENCH: Lazy<WordMap> = sync_lazy! { gen_wordmap(&WORDLIST_FRENCH) };
+    pub static WORDMAP_FRENCH: Lazy<WordMap> = Lazy::new(|| gen_wordmap(&WORDLIST_FRENCH));
     #[cfg(feature = "italian")]
-    pub static WORDMAP_ITALIAN: Lazy<WordMap> = sync_lazy! { gen_wordmap(&WORDLIST_ITALIAN) };
+    pub static WORDMAP_ITALIAN: Lazy<WordMap> = Lazy::new(|| gen_wordmap(&WORDLIST_ITALIAN));
     #[cfg(feature = "japanese")]
-    pub static WORDMAP_JAPANESE: Lazy<WordMap> = sync_lazy! { gen_wordmap(&WORDLIST_JAPANESE) };
+    pub static WORDMAP_JAPANESE: Lazy<WordMap> = Lazy::new(|| gen_wordmap(&WORDLIST_JAPANESE));
     #[cfg(feature = "korean")]
-    pub static WORDMAP_KOREAN: Lazy<WordMap> = sync_lazy! { gen_wordmap(&WORDLIST_KOREAN) };
+    pub static WORDMAP_KOREAN: Lazy<WordMap> = Lazy::new(|| gen_wordmap(&WORDLIST_KOREAN));
     #[cfg(feature = "spanish")]
-    pub static WORDMAP_SPANISH: Lazy<WordMap> = sync_lazy! { gen_wordmap(&WORDLIST_SPANISH) };
+    pub static WORDMAP_SPANISH: Lazy<WordMap> = Lazy::new(|| gen_wordmap(&WORDLIST_SPANISH));
 }
 
 /// The language determines which words will be used in a mnemonic phrase, but also indirectly

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,12 +29,6 @@
 //!
 #[macro_use]
 extern crate failure;
-#[macro_use]
-extern crate once_cell;
-extern crate hashbrown;
-extern crate hmac;
-extern crate pbkdf2;
-extern crate sha2;
 
 mod error;
 mod language;

--- a/src/mnemonic.rs
+++ b/src/mnemonic.rs
@@ -1,10 +1,10 @@
-use crypto::{gen_random_bytes, sha256_first_byte};
-use error::ErrorKind;
-use failure::Error;
-use language::Language;
-use mnemonic_type::MnemonicType;
 use std::fmt;
-use util::{checksum, BitWriter, IterExt};
+use failure::Error;
+use crate::crypto::{gen_random_bytes, sha256_first_byte};
+use crate::error::ErrorKind;
+use crate::language::Language;
+use crate::mnemonic_type::MnemonicType;
+use crate::util::{checksum, BitWriter, IterExt};
 
 /// The primary type in this crate, most tasks require creating or using one.
 ///

--- a/src/mnemonic_type.rs
+++ b/src/mnemonic_type.rs
@@ -1,6 +1,6 @@
-use error::ErrorKind;
-use failure::Error;
 use std::fmt;
+use failure::Error;
+use crate::error::ErrorKind;
 
 const ENTROPY_OFFSET: usize = 8;
 

--- a/src/seed.rs
+++ b/src/seed.rs
@@ -1,6 +1,6 @@
-use crypto::pbkdf2;
-use mnemonic::Mnemonic;
 use std::fmt;
+use crate::crypto::pbkdf2;
+use crate::mnemonic::Mnemonic;
 
 /// The secret value used to derive HD wallet addresses from a [`Mnemonic`][Mnemonic] phrase.
 ///
@@ -81,7 +81,7 @@ impl fmt::UpperHex for Seed {
 #[cfg(test)]
 mod test {
     use super::*;
-    use language::Language;
+    use crate::language::Language;
 
     #[test]
     fn seed_hex_format() {


### PR DESCRIPTION
- `Mnemonic::from_phrase` now takes `&str` as argument and sanitizes the whitespace characters (by @rob-solana #9).
- Updates dependencies (Closes #5).
- Updated edition to 2018.
- Bumped version to 0.7.0.