### PR TITLE
Normalize phrase and password according to specification

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ hmac = "0.7.1"
 pbkdf2 = { version = "0.3.0", default-features = false }
 rand = "0.7.2"
 once_cell = { version = "1.2.0", features = [ "parking_lot" ] }
+unicode-normalization = "0.1.12"
 
 [dev-dependencies]
 hex = "0.4.0"

--- a/src/language.rs
+++ b/src/language.rs
@@ -173,3 +173,62 @@ impl Default for Language {
         Language::English
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::lazy;
+    use super::WordList;
+
+    fn is_wordlist_nfkd(wl: &WordList) -> bool {
+        for idx in 0..2047 {
+            let word = wl.get_word(idx.into());
+            if !unicode_normalization::is_nfkd(word) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    #[test]
+    #[cfg(feature = "chinese-simplified")]
+    fn chinese_simplified_wordlist_is_nfkd() {
+        assert!(is_wordlist_nfkd(&lazy::WORDLIST_CHINESE_SIMPLIFIED));
+    }
+
+    #[test]
+    #[cfg(feature = "chinese-traditional")]
+    fn chinese_traditional_wordlist_is_nfkd() {
+        assert!(is_wordlist_nfkd(&lazy::WORDLIST_CHINESE_TRADITIONAL));
+    }
+
+    #[test]
+    #[cfg(feature = "french")]
+    fn french_wordlist_is_nfkd() {
+        assert!(is_wordlist_nfkd(&lazy::WORDLIST_FRENCH));
+    }
+
+    #[test]
+    #[cfg(feature = "italian")]
+    fn italian_wordlist_is_nfkd() {
+        assert!(is_wordlist_nfkd(&lazy::WORDLIST_ITALIAN));
+    }
+
+    #[test]
+    #[cfg(feature = "japanese")]
+    fn japanese_wordlist_is_nfkd() {
+        assert!(is_wordlist_nfkd(&lazy::WORDLIST_JAPANESE));
+    }
+
+    #[test]
+    #[cfg(feature = "korean")]
+    fn korean_wordlist_is_nfkd() {
+        assert!(is_wordlist_nfkd(&lazy::WORDLIST_KOREAN));
+    }
+
+    #[test]
+    #[cfg(feature = "spanish")]
+    fn spanish_wordlist_is_nfkd() {
+        assert!(is_wordlist_nfkd(&lazy::WORDLIST_SPANISH));
+    }
+
+}

--- a/src/mnemonic.rs
+++ b/src/mnemonic.rs
@@ -1,5 +1,6 @@
 use std::fmt;
 use failure::Error;
+use unicode_normalization::UnicodeNormalization;
 use crate::crypto::{gen_random_bytes, sha256_first_byte};
 use crate::error::ErrorKind;
 use crate::language::Language;
@@ -134,7 +135,9 @@ impl Mnemonic {
     ///
     /// [Mnemonic]: ../mnemonic/struct.Mnemonic.html
     pub fn from_phrase(phrase: &str, lang: Language) -> Result<Mnemonic, Error> {
-        let phrase: String = phrase.split_whitespace().join(" ");
+        let words = phrase.split_whitespace();
+        let mut normalized_words = words.map(|w| w.nfkd().to_string());
+        let phrase: String = normalized_words.join(" ");
 
         // this also validates the checksum and phrase length before returning the entropy so we
         // can store it. We don't use the validate function here to avoid having a public API that

--- a/src/seed.rs
+++ b/src/seed.rs
@@ -1,4 +1,5 @@
 use std::fmt;
+use unicode_normalization::UnicodeNormalization;
 use crate::crypto::pbkdf2;
 use crate::mnemonic::Mnemonic;
 
@@ -27,7 +28,8 @@ impl Seed {
     /// [Mnemonic]: ./mnemonic/struct.Mnemonic.html
     pub fn new(mnemonic: &Mnemonic, password: &str) -> Self {
         let salt = format!("mnemonic{}", password);
-        let bytes = pbkdf2(mnemonic.phrase().as_bytes(), &salt);
+        let normalized_salt = salt.nfkd().to_string();
+        let bytes = pbkdf2(mnemonic.phrase().as_bytes(), &normalized_salt);
 
         Self { bytes }
     }
@@ -97,5 +99,68 @@ mod test {
         assert_eq!(format!("{:X}", seed), "0BDE96F14C35A66235478E0C16C152FCAF6301E4D9A81D3FEBC50879FE7E5438E6A8DD3E39BDF3AB7B12D6B44218710E17D7A2844EE9633FAB0E03D9A6C8569B");
         assert_eq!(format!("{:#x}", seed), "0x0bde96f14c35a66235478e0c16c152fcaf6301e4d9a81d3febc50879fe7e5438e6a8dd3e39bdf3ab7b12d6b44218710e17d7a2844ee9633fab0e03d9a6c8569b");
         assert_eq!(format!("{:#X}", seed), "0x0BDE96F14C35A66235478E0C16C152FCAF6301E4D9A81D3FEBC50879FE7E5438E6A8DD3E39BDF3AB7B12D6B44218710E17D7A2844EE9633FAB0E03D9A6C8569B");
+    }
+
+    fn test_unicode_normalization(lang: Language, phrase: &str, password: &str, expected_seed_hex: &str) {
+        let mnemonic = Mnemonic::from_phrase(phrase, lang).unwrap();
+        let seed = Seed::new(&mnemonic, password);
+        assert_eq!(format!("{:x}", seed), expected_seed_hex);
+    }
+
+    #[test]
+    /// Test vector is derived from https://github.com/infincia/bip39-rs/issues/26#issuecomment-586476647
+    #[cfg(feature = "spanish")]
+    fn issue_26() {
+        test_unicode_normalization(
+            Language::Spanish,
+            "camello pomelo toque oponer urgente lástima merengue cutis tirón pudor pomo barco",
+            "el español se habla en muchos países",
+            "67a2cf87b9d110dd5210275fd4d7a107a0a0dd9446e02f3822f177365786ae440b8873693c88f732834af90785753d989a367f7094230901b204c567718ce6be",
+        );
+    }
+
+    #[test]
+    /// https://github.com/MetacoSA/NBitcoin/blob/master/NBitcoin.Tests/data/bip39_vectors.en.json
+    fn password_is_unicode_normalized() {
+        test_unicode_normalization(
+            Language::English,
+            "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about",
+            "nullius　à　nym.zone ¹teſts² English",
+            "61f3aa13adcf5f4b8661fc062501d67eca3a53fc0ed129076ad7a22983b6b5ed0e84e47b24cff23b7fca57e127f62f28c1584ed487872d4bfbc773257bdbc434",
+        );
+    }
+
+    #[test]
+    /// https://github.com/bip32JP/bip32JP.github.io/commit/360c05a6439e5c461bbe5e84c7567ec38eb4ac5f
+    #[cfg(feature = "japanese")]
+    fn japanese_normalization_1() {
+        test_unicode_normalization(
+            Language::Japanese,
+            "あいこくしん　あいこくしん　あいこくしん　あいこくしん　あいこくしん　あいこくしん　あいこくしん　あいこくしん　あいこくしん　あいこくしん　あいこくしん　あおぞら",
+            "㍍ガバヴァぱばぐゞちぢ十人十色",
+            "a262d6fb6122ecf45be09c50492b31f92e9beb7d9a845987a02cefda57a15f9c467a17872029a9e92299b5cbdf306e3a0ee620245cbd508959b6cb7ca637bd55",
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "japanese")]
+    fn japanese_normalization_2() {
+        test_unicode_normalization(
+            Language::Japanese,
+            "うちゅう　ふそく　ひしょ　がちょう　うけもつ　めいそう　みかん　そざい　いばる　うけとる　さんま　さこつ　おうさま　ぱんつ　しひょう　めした　たはつ　いちぶ　つうじょう　てさぎょう　きつね　みすえる　いりぐち　かめれおん",
+            "㍍ガバヴァぱばぐゞちぢ十人十色",
+            "346b7321d8c04f6f37b49fdf062a2fddc8e1bf8f1d33171b65074531ec546d1d3469974beccb1a09263440fc92e1042580a557fdce314e27ee4eabb25fa5e5fe",
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "french")]
+    fn french_normalization() {
+        test_unicode_normalization(
+            Language::French,
+            "paternel xénon curatif séparer docile capable exigence boulon styliste plexus surface embryon crayon gorge exister",
+            "nullius　à　nym.zone ¹teſts² Français",
+            "cff9ffd2b23549e73601db4129a334c81b28a40f0ee819b5d6a54c409999f0dfb6b89df17cae6408c96786165c205403d283baadc03ffdd391a490923b7d9493",
+        );
     }
 }


### PR DESCRIPTION
I have not pulled in too many test cases, because if these all pass and a few that I missed would not, that would clearly be an issue with the [unicode-normalization crate](https://crates.io/crates/unicode-normalization).