### PR TITLE
chore: No need to allocate temporary strings on nfkd

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "tiny-bip39"
-version = "0.7.1"
+version = "0.7.2"
 authors = [
     "Stephen Oliver <steve@infincia.com>",
-    "Maciej Hirsz <hello@maciej.codes",
+    "Maciej Hirsz <hello@maciej.codes>",
 ]
 license = "MIT/Apache-2.0"
 homepage = "https://github.com/maciejhirsz/tiny-bip39/"

--- a/src/mnemonic.rs
+++ b/src/mnemonic.rs
@@ -135,9 +135,10 @@ impl Mnemonic {
     ///
     /// [Mnemonic]: ../mnemonic/struct.Mnemonic.html
     pub fn from_phrase(phrase: &str, lang: Language) -> Result<Mnemonic, Error> {
-        let words = phrase.split_whitespace();
-        let mut normalized_words = words.map(|w| w.nfkd().to_string());
-        let phrase: String = normalized_words.join(" ");
+        let phrase = phrase
+            .split_whitespace()
+            .map(|w| w.nfkd())
+            .join::<String>(" ");
 
         // this also validates the checksum and phrase length before returning the entropy so we
         // can store it. We don't use the validate function here to avoid having a public API that


### PR DESCRIPTION
+ Removing `.to_string()` and joining iterators directly.