### PR TITLE
CustomLanguage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tiny-bip39"
-version = "0.8.0"
+version = "0.9.0"
 authors = [
     "Stephen Oliver <steve@infincia.com>",
     "Maciej Hirsz <hello@maciej.codes>",
@@ -21,14 +21,14 @@ path = "src/lib.rs"
 [features]
 chinese-simplified = []
 chinese-traditional = []
-# Note: English is the standard for bip39 so always included
+english = []
 french = []
 italian = []
 japanese = []
 korean = []
 spanish = []
 
-default = ["chinese-simplified", "chinese-traditional", "french", "italian", "japanese", "korean", "spanish"]
+default = ["english", "chinese-simplified", "chinese-traditional", "french", "italian", "japanese", "korean", "spanish"]
 
 [dependencies]
 anyhow = "1.0.34"

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,12 +1,17 @@
 use crate::mnemonic_type::MnemonicType;
 use thiserror::Error;
 
+#[cfg_attr(test, derive(PartialEq))]
 #[derive(Debug, Error)]
 pub enum ErrorKind {
     #[error("invalid checksum")]
     InvalidChecksum,
     #[error("invalid word in phrase")]
     InvalidWord,
+    #[error("word list is unordered")]
+    InvalidOrder,
+    #[error("found {0} words in source, expected 2048")]
+    InvalidWordCount(usize),
     #[error("invalid keysize: {0}")]
     InvalidKeysize(usize),
     #[error("invalid number of words in phrase: {0}")]

--- a/src/language.rs
+++ b/src/language.rs
@@ -1,17 +1,19 @@
+use std::fmt;
+use std::cmp::Ordering;
 use crate::error::ErrorKind;
 use crate::util::{Bits, Bits11};
 use rustc_hash::FxHashMap;
 use zeroize::Zeroize;
 
-pub struct WordMap {
-    inner: FxHashMap<&'static str, Bits11>,
+pub struct WordMap<'a> {
+    inner: FxHashMap<&'a str, Bits11>,
 }
 
-pub struct WordList {
-    inner: Vec<&'static str>,
+pub struct WordList<'a> {
+    inner: Vec<&'a str>,
 }
 
-impl WordMap {
+impl WordMap<'_> {
     pub fn get_bits(&self, word: &str) -> Result<Bits11, ErrorKind> {
         match self.inner.get(word) {
             Some(n) => Ok(*n),
@@ -20,12 +22,12 @@ impl WordMap {
     }
 }
 
-impl WordList {
-    pub fn get_word(&self, bits: Bits11) -> &'static str {
+impl WordList<'_> {
+    pub fn get_word(&self, bits: Bits11) -> &str {
         self.inner[bits.bits() as usize]
     }
 
-    pub fn get_words_by_prefix(&self, prefix: &str) -> &[&'static str] {
+    pub fn get_words_by_prefix(&self, prefix: &str) -> &[&str] {
         let start = self.inner
             .binary_search(&prefix)
             .unwrap_or_else(|idx| idx);
@@ -37,22 +39,9 @@ impl WordList {
     }
 }
 
-mod lazy {
-    use super::{Bits11, WordList, WordMap};
-    use once_cell::sync::Lazy;
-
-    /// lazy generation of the word list
-    fn gen_wordlist(lang_words: &'static str) -> WordList {
-        let inner: Vec<_> = lang_words.split_whitespace().collect();
-
-        debug_assert!(inner.len() == 2048, "Invalid wordlist length");
-
-        WordList { inner }
-    }
-
-    /// lazy generation of the word map
-    fn gen_wordmap(wordlist: &WordList) -> WordMap {
-        let inner = wordlist
+impl WordList<'static> {
+    fn gen_wordmap(&self) -> WordMap<'static> {
+        let inner = self
             .inner
             .iter()
             .enumerate()
@@ -60,6 +49,20 @@ mod lazy {
             .collect();
 
         WordMap { inner }
+    }
+}
+
+mod lazy {
+    use super::{WordList, WordMap};
+    use once_cell::sync::Lazy;
+
+    /// lazy generation of the word list
+    fn gen_wordlist(lang_words: &'static str) -> WordList<'static> {
+        let inner: Vec<_> = lang_words.split_whitespace().collect();
+
+        debug_assert!(inner.len() == 2048, "Invalid wordlist length");
+
+        WordList { inner }
     }
 
     pub static WORDLIST_ENGLISH: Lazy<WordList> =
@@ -86,23 +89,23 @@ mod lazy {
     pub static WORDLIST_SPANISH: Lazy<WordList> =
         Lazy::new(|| gen_wordlist(include_str!("langs/spanish.txt")));
 
-    pub static WORDMAP_ENGLISH: Lazy<WordMap> = Lazy::new(|| gen_wordmap(&WORDLIST_ENGLISH));
+    pub static WORDMAP_ENGLISH: Lazy<WordMap> = Lazy::new(|| WORDLIST_ENGLISH.gen_wordmap());
     #[cfg(feature = "chinese-simplified")]
     pub static WORDMAP_CHINESE_SIMPLIFIED: Lazy<WordMap> =
-        Lazy::new(|| gen_wordmap(&WORDLIST_CHINESE_SIMPLIFIED));
+        Lazy::new(|| WORDLIST_CHINESE_SIMPLIFIED.gen_wordmap());
     #[cfg(feature = "chinese-traditional")]
     pub static WORDMAP_CHINESE_TRADITIONAL: Lazy<WordMap> =
-        Lazy::new(|| gen_wordmap(&WORDLIST_CHINESE_TRADITIONAL));
+        Lazy::new(|| WORDLIST_CHINESE_TRADITIONAL.gen_wordmap());
     #[cfg(feature = "french")]
-    pub static WORDMAP_FRENCH: Lazy<WordMap> = Lazy::new(|| gen_wordmap(&WORDLIST_FRENCH));
+    pub static WORDMAP_FRENCH: Lazy<WordMap> = Lazy::new(|| WORDLIST_FRENCH.gen_wordmap());
     #[cfg(feature = "italian")]
-    pub static WORDMAP_ITALIAN: Lazy<WordMap> = Lazy::new(|| gen_wordmap(&WORDLIST_ITALIAN));
+    pub static WORDMAP_ITALIAN: Lazy<WordMap> = Lazy::new(|| WORDLIST_ITALIAN.gen_wordmap());
     #[cfg(feature = "japanese")]
-    pub static WORDMAP_JAPANESE: Lazy<WordMap> = Lazy::new(|| gen_wordmap(&WORDLIST_JAPANESE));
+    pub static WORDMAP_JAPANESE: Lazy<WordMap> = Lazy::new(|| WORDLIST_JAPANESE.gen_wordmap());
     #[cfg(feature = "korean")]
-    pub static WORDMAP_KOREAN: Lazy<WordMap> = Lazy::new(|| gen_wordmap(&WORDLIST_KOREAN));
+    pub static WORDMAP_KOREAN: Lazy<WordMap> = Lazy::new(|| WORDLIST_KOREAN.gen_wordmap());
     #[cfg(feature = "spanish")]
-    pub static WORDMAP_SPANISH: Lazy<WordMap> = Lazy::new(|| gen_wordmap(&WORDLIST_SPANISH));
+    pub static WORDMAP_SPANISH: Lazy<WordMap> = Lazy::new(|| WORDLIST_SPANISH.gen_wordmap());
 }
 
 /// The language determines which words will be used in a mnemonic phrase, but also indirectly
@@ -116,6 +119,7 @@ mod lazy {
 #[derive(Debug, Clone, Copy, PartialEq, Zeroize)]
 #[zeroize(drop)]
 pub enum Language {
+    #[cfg(feature = "english")]
     English,
     #[cfg(feature = "chinese-simplified")]
     ChineseSimplified,
@@ -131,6 +135,12 @@ pub enum Language {
     Korean,
     #[cfg(feature = "spanish")]
     Spanish,
+}
+
+pub trait LangTrait: Copy + fmt::Debug {
+    fn wordlist<'a>(&'a self) -> &'a WordList<'a>;
+
+    fn wordmap<'a>(&'a self) -> &'a WordMap<'a>;
 }
 
 impl Language {
@@ -156,9 +166,11 @@ impl Language {
             _ => None,
         }
     }
+}
 
+impl LangTrait for Language {
     /// Get the word list for this language
-    pub fn wordlist(&self) -> &'static WordList {
+    fn wordlist<'a>(&'a self) -> &'a WordList<'a> {
         match *self {
             Language::English => &lazy::WORDLIST_ENGLISH,
             #[cfg(feature = "chinese-simplified")]
@@ -182,7 +194,7 @@ impl Language {
     ///
     /// The index of an individual word in the word list is used as the binary value of that word
     /// when the phrase is turned into a [`Seed`][Seed].
-    pub fn wordmap(&self) -> &'static WordMap {
+    fn wordmap<'a>(&'a self) -> &'a WordMap<'a> {
         match *self {
             Language::English => &lazy::WORDMAP_ENGLISH,
             #[cfg(feature = "chinese-simplified")]
@@ -209,13 +221,100 @@ impl Default for Language {
     }
 }
 
+/// Helper that allows you to add a new dictionary for a custom language,
+/// as long as the word list contains exactly 2048 sorted words.
+///
+/// # Example
+///
+/// ```
+/// use bip39::{Mnemonic, MnemonicType, CustomLanguage};
+///
+/// // Supply your own list
+/// static BIP39_ENGLISH: &str = include_str!("langs/english.txt");
+///
+/// let language = CustomLanguage::new(BIP39_ENGLISH).unwrap();
+/// let phrase = "crop cash unable insane eight faith inflict route frame loud box vibrant";
+/// let mnemonic = Mnemonic::from_phrase(phrase, &language).unwrap();
+///
+/// assert_eq!("33E46BB13A746EA41CDDE45C90846A79", format!("{:X}", mnemonic));
+/// ```
+pub struct CustomLanguage {
+    _source: Box<str>,
+    // We use 'static here, but really we borrow from `source`
+    map: WordMap<'static>,
+    // We use 'static here, but really we borrow from `source`
+    list: WordList<'static>,
+}
+
+impl fmt::Debug for CustomLanguage {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.list.inner.fmt(f)
+    }
+}
+
+impl CustomLanguage {
+    /// Create a new `Custom` language from a single list of pre-sorted words.
+    /// Words must be separate by at least one Unicode whitespace character,
+    /// those include space (U+0020) and line feed (U+000A).
+    ///
+    /// This will return an error if the words are not sorted alphabetically,
+    /// or if the total count of words isn't 2048.
+    pub fn new(source: impl Into<Box<str>>) -> Result<Self, ErrorKind> {
+        let source = source.into();
+
+        let mut last_word = "";
+
+        let inner = source
+            .split_whitespace()
+            .map(|word| {
+                let word = unsafe {
+                    // Re-borrow to get a 'static lifetime. This means that we must
+                    // always narrow down the lifetime back to the lifetime of this
+                    // CustomLanguage (which contains the `source`), so that the
+                    // refs are guaranteed not to outlive the `source`!!
+                    &*(word as *const str)
+                };
+
+                match word.cmp(last_word) {
+                    Ordering::Greater => {
+                        last_word = word;
+                        Ok(word)
+                    },
+                    _ => Err(ErrorKind::InvalidOrder)
+                }
+            }).collect::<Result<Vec<&'static str>, _>>()?;
+
+        if inner.len() != 2048 {
+            return Err(ErrorKind::InvalidWordCount(inner.len()));
+        }
+
+        let list = WordList { inner };
+        let map = list.gen_wordmap();
+
+        Ok(Self {
+            _source: source,
+            map,
+            list,
+        })
+    }
+}
+
+impl LangTrait for &CustomLanguage {
+    fn wordlist<'a>(&'a self) -> &'a WordList<'a> {
+        &self.list
+    }
+
+    fn wordmap<'a>(&'a self) -> &'a WordMap<'a> {
+        &self.map
+    }
+}
+
 #[cfg(test)]
 mod test {
-    use super::lazy;
-    use super::Language;
-    use super::WordList;
+    use super::*;
 
     #[test]
+    #[cfg(feature = "english")]
     fn words_by_prefix() {
         let wl = &lazy::WORDLIST_ENGLISH;
         let res = wl.get_words_by_prefix("woo");
@@ -223,6 +322,7 @@ mod test {
     }
 
     #[test]
+    #[cfg(feature = "english")]
     fn all_words_by_prefix() {
         let wl = &lazy::WORDLIST_ENGLISH;
         let res = wl.get_words_by_prefix("");
@@ -230,6 +330,7 @@ mod test {
     }
 
     #[test]
+    #[cfg(feature = "english")]
     fn words_by_invalid_prefix() {
         let wl = &lazy::WORDLIST_ENGLISH;
         let res = wl.get_words_by_prefix("woof");
@@ -362,5 +463,23 @@ mod test {
     #[test]
     fn from_invalid_language_code() {
         assert_eq!(Language::from_language_code("not a real language"), None);
+    }
+
+    #[test]
+    fn custom_language_invalid_order() {
+        assert_eq!(CustomLanguage::new("alpha\ngamma\nbeta").unwrap_err(), ErrorKind::InvalidOrder);
+    }
+
+    #[test]
+    fn custom_language_invalid_count() {
+        assert_eq!(CustomLanguage::new("alpha\nbeta\ngamma").unwrap_err(), ErrorKind::InvalidWordCount(3));
+    }
+
+    #[test]
+    #[cfg(feature = "english")]
+    fn custom_language_english() {
+        let lang = CustomLanguage::new(include_str!("langs/english.txt")).unwrap();
+
+        assert_eq!(&lang.list.inner, &lazy::WORDLIST_ENGLISH.inner);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,7 @@ mod util;
 mod crypto;
 
 pub use error::ErrorKind;
-pub use language::Language;
+pub use language::{Language, CustomLanguage, LangTrait};
 pub use mnemonic::Mnemonic;
 pub use mnemonic_type::MnemonicType;
 pub use seed::Seed;

--- a/src/mnemonic_type.rs
+++ b/src/mnemonic_type.rs
@@ -29,6 +29,7 @@ const ENTROPY_OFFSET: usize = 8;
 /// [Mnemonic]: ../mnemonic/struct.Mnemonic.html
 /// [Seed]: ../seed/struct.Seed.html
 ///
+#[cfg_attr(test, derive(PartialEq))]
 #[derive(Debug, Copy, Clone)]
 pub enum MnemonicType {
     //  ... = (entropy_bits << ...)   | checksum_bits

--- a/src/seed.rs
+++ b/src/seed.rs
@@ -3,6 +3,7 @@ use unicode_normalization::UnicodeNormalization;
 use zeroize::Zeroize;
 use crate::crypto::pbkdf2;
 use crate::mnemonic::Mnemonic;
+use crate::language::LangTrait;
 
 /// The secret value used to derive HD wallet addresses from a [`Mnemonic`][Mnemonic] phrase.
 ///
@@ -30,7 +31,7 @@ impl Seed {
     /// Generates the seed from the [`Mnemonic`][Mnemonic] and the password.
     ///
     /// [Mnemonic]: ./mnemonic/struct.Mnemonic.html
-    pub fn new(mnemonic: &Mnemonic, password: &str) -> Self {
+    pub fn new<Lang: LangTrait>(mnemonic: &Mnemonic<Lang>, password: &str) -> Self {
         let salt = format!("mnemonic{}", password);
         let normalized_salt = salt.nfkd().to_string();
         let bytes = pbkdf2(mnemonic.phrase().as_bytes(), &normalized_salt);


### PR DESCRIPTION
+ English language support now needs to be enabled by a feature if default features are disabled.
+ Added `CustomLanguage` that allows wordlist to be provided from the outside.
+ `Mnemonic` is now generic over implementations of `LangTrait`, which is implemented for the `Language` enum and the `&CustomLanguage`. `Mnemonic` type defaults to `Mnemonic<Language>`.