### PR TITLE
Improve compatibility with the wasm32-unknown-unknown target

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,8 @@ sha2 = "0.9.1"
 hmac = "0.8.1"
 pbkdf2 = { version = "0.4.0", default-features = false }
 rand = "0.7.3"
-once_cell = { version = "1.4.0", features = [ "parking_lot" ] }
+once_cell = { version = "1.8.0", features = ["parking_lot"] }
+parking_lot = { version = "0.11.1", features = ["wasm-bindgen"] }
 unicode-normalization = "0.1.13"
 zeroize = { version = "1.1.1", features = ["zeroize_derive"] }
 


### PR DESCRIPTION
This crate uses the once_cell crate for having some singletons. These singletons are sync and can be used from multiple threads, and the once_cell crate can optionally use the parking_lot implementations for improving fairness.

Unfortunately because of Amanieu/parking_lot#269 this forbids usage of the tiny-bip39 crate compiled into pure WASM from nodejs. This PR might be a breaking change for the tiny-bip39 users, but those who are affected can put `once_cell = { version = "1.4.0", features = [ "parking_lot" ] }` into their own cargo.toml to enforce using the fair synchronization primitives from the parking_lot crate.