### PR TITLE
Enable wasm feature only when required

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,9 +39,13 @@ hmac = "0.8.1"
 pbkdf2 = { version = "0.4.0", default-features = false }
 rand = "0.7.3"
 once_cell = { version = "1.8.0", features = ["parking_lot"] }
-parking_lot = { version = "0.11.1", features = ["wasm-bindgen"] }
+parking_lot = "0.11.1"
 unicode-normalization = "0.1.13"
 zeroize = { version = "1.1.1", features = ["zeroize_derive"] }
+
+[target.'cfg(target_arch = "wasm32")'.dependencies.parking_lot]
+version = "0.11.1"
+features = ["wasm-bindgen"]
 
 [dev-dependencies]
 hex = "0.4.2"


### PR DESCRIPTION
This PR will change how WASM dependency is resolved for this crate.

Following up #28, WASM support is only enabled when it is requested.