### PR TITLE
Add proper WASM support feature flags and tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,10 +38,19 @@ sha2 = "0.9.1"
 hmac = "0.8.1"
 pbkdf2 = { version = "0.4.0", default-features = false }
 rand = "0.7.3"
-once_cell = { version = "1.8.0", features = ["parking_lot"] }
-parking_lot = { version = "0.11.1", features = ["wasm-bindgen"] }
+once_cell = { version = "1.8.0" }
 unicode-normalization = "0.1.13"
 zeroize = { version = "1.1.1", features = ["zeroize_derive"] }
 
 [dev-dependencies]
 hex = "0.4.2"
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+wasm-bindgen = "0.2"
+
+[target.'cfg(target_arch = "wasm32")'.dependencies.rand]
+version = "0.7.3"
+features = ["wasm-bindgen"]
+
+[target.'cfg(target_arch = "wasm32")'.dev-dependencies]
+wasm-bindgen-test = "0.3"

--- a/src/error.rs
+++ b/src/error.rs
@@ -18,8 +18,11 @@ pub enum ErrorKind {
 #[cfg(test)]
 mod test {
     use super::*;
+    #[cfg(target_arch = "wasm32")]
+    use wasm_bindgen_test::*;
 
-    #[test]
+    #[cfg_attr(all(target_arch = "wasm32"), wasm_bindgen_test)]
+    #[cfg_attr(not(target_arch = "wasm32"), test)]
     fn prints_correctly() {
         assert_eq!(
             format!("{}", ErrorKind::InvalidChecksum),
@@ -30,7 +33,10 @@ mod test {
             "invalid keysize: 42",
         );
         assert_eq!(
-            format!("{}", ErrorKind::InvalidEntropyLength(42, MnemonicType::Words12)),
+            format!(
+                "{}",
+                ErrorKind::InvalidEntropyLength(42, MnemonicType::Words12)
+            ),
             "invalid entropy length 42bits for mnemonic type Words12",
         );
     }

--- a/src/language.rs
+++ b/src/language.rs
@@ -212,22 +212,27 @@ mod test {
     use super::lazy;
     use super::Language;
     use super::WordList;
+    #[cfg(target_arch = "wasm32")]
+    use wasm_bindgen_test::*;
 
-    #[test]
+    #[cfg_attr(all(target_arch = "wasm32"), wasm_bindgen_test)]
+    #[cfg_attr(not(target_arch = "wasm32"), test)]
     fn words_by_prefix() {
         let wl = &lazy::WORDLIST_ENGLISH;
         let res = wl.get_words_by_prefix("woo");
         assert_eq!(res, ["wood","wool"]);
     }
 
-    #[test]
+    #[cfg_attr(all(target_arch = "wasm32"), wasm_bindgen_test)]
+    #[cfg_attr(not(target_arch = "wasm32"), test)]
     fn all_words_by_prefix() {
         let wl = &lazy::WORDLIST_ENGLISH;
         let res = wl.get_words_by_prefix("");
         assert_eq!(res.len(), 2048);
     }
 
-    #[test]
+    #[cfg_attr(all(target_arch = "wasm32"), wasm_bindgen_test)]
+    #[cfg_attr(not(target_arch = "wasm32"), test)]
     fn words_by_invalid_prefix() {
         let wl = &lazy::WORDLIST_ENGLISH;
         let res = wl.get_words_by_prefix("woof");
@@ -244,49 +249,57 @@ mod test {
         return true;
     }
 
-    #[test]
+    #[cfg_attr(all(target_arch = "wasm32"), wasm_bindgen_test)]
+    #[cfg_attr(not(target_arch = "wasm32"), test)]
     #[cfg(feature = "chinese-simplified")]
     fn chinese_simplified_wordlist_is_nfkd() {
         assert!(is_wordlist_nfkd(&lazy::WORDLIST_CHINESE_SIMPLIFIED));
     }
 
-    #[test]
+    #[cfg_attr(all(target_arch = "wasm32"), wasm_bindgen_test)]
+    #[cfg_attr(not(target_arch = "wasm32"), test)]
     #[cfg(feature = "chinese-traditional")]
     fn chinese_traditional_wordlist_is_nfkd() {
         assert!(is_wordlist_nfkd(&lazy::WORDLIST_CHINESE_TRADITIONAL));
     }
 
-    #[test]
+    #[cfg_attr(all(target_arch = "wasm32"), wasm_bindgen_test)]
+    #[cfg_attr(not(target_arch = "wasm32"), test)]
     #[cfg(feature = "french")]
     fn french_wordlist_is_nfkd() {
         assert!(is_wordlist_nfkd(&lazy::WORDLIST_FRENCH));
     }
 
-    #[test]
+    #[cfg_attr(all(target_arch = "wasm32"), wasm_bindgen_test)]
+    #[cfg_attr(not(target_arch = "wasm32"), test)]
     #[cfg(feature = "italian")]
     fn italian_wordlist_is_nfkd() {
         assert!(is_wordlist_nfkd(&lazy::WORDLIST_ITALIAN));
     }
 
-    #[test]
+    #[cfg_attr(all(target_arch = "wasm32"), wasm_bindgen_test)]
+    #[cfg_attr(not(target_arch = "wasm32"), test)]
     #[cfg(feature = "japanese")]
     fn japanese_wordlist_is_nfkd() {
         assert!(is_wordlist_nfkd(&lazy::WORDLIST_JAPANESE));
     }
 
-    #[test]
+    #[cfg_attr(all(target_arch = "wasm32"), wasm_bindgen_test)]
+    #[cfg_attr(not(target_arch = "wasm32"), test)]
     #[cfg(feature = "korean")]
     fn korean_wordlist_is_nfkd() {
         assert!(is_wordlist_nfkd(&lazy::WORDLIST_KOREAN));
     }
 
-    #[test]
+    #[cfg_attr(all(target_arch = "wasm32"), wasm_bindgen_test)]
+    #[cfg_attr(not(target_arch = "wasm32"), test)]
     #[cfg(feature = "spanish")]
     fn spanish_wordlist_is_nfkd() {
         assert!(is_wordlist_nfkd(&lazy::WORDLIST_SPANISH));
     }
 
-    #[test]
+    #[cfg_attr(all(target_arch = "wasm32"), wasm_bindgen_test)]
+    #[cfg_attr(not(target_arch = "wasm32"), test)]
     fn from_language_code_en() {
         assert_eq!(
             Language::from_language_code("En").expect("en is a valid language"),
@@ -294,7 +307,8 @@ mod test {
         );
     }
 
-    #[test]
+    #[cfg_attr(all(target_arch = "wasm32"), wasm_bindgen_test)]
+    #[cfg_attr(not(target_arch = "wasm32"), test)]
     #[cfg(feature = "chinese-simplified")]
     fn from_language_code_cn_hans() {
         assert_eq!(
@@ -303,7 +317,8 @@ mod test {
         );
     }
 
-    #[test]
+    #[cfg_attr(all(target_arch = "wasm32"), wasm_bindgen_test)]
+    #[cfg_attr(not(target_arch = "wasm32"), test)]
     #[cfg(feature = "chinese-traditional")]
     fn from_language_code_cn_hant() {
         assert_eq!(
@@ -312,7 +327,8 @@ mod test {
         );
     }
 
-    #[test]
+    #[cfg_attr(all(target_arch = "wasm32"), wasm_bindgen_test)]
+    #[cfg_attr(not(target_arch = "wasm32"), test)]
     #[cfg(feature = "french")]
     fn from_language_code_fr() {
         assert_eq!(
@@ -321,7 +337,8 @@ mod test {
         );
     }
 
-    #[test]
+    #[cfg_attr(all(target_arch = "wasm32"), wasm_bindgen_test)]
+    #[cfg_attr(not(target_arch = "wasm32"), test)]
     #[cfg(feature = "italian")]
     fn from_language_code_it() {
         assert_eq!(
@@ -330,7 +347,8 @@ mod test {
         );
     }
 
-    #[test]
+    #[cfg_attr(all(target_arch = "wasm32"), wasm_bindgen_test)]
+    #[cfg_attr(not(target_arch = "wasm32"), test)]
     #[cfg(feature = "japanese")]
     fn from_language_code_ja() {
         assert_eq!(
@@ -339,7 +357,8 @@ mod test {
         );
     }
 
-    #[test]
+    #[cfg_attr(all(target_arch = "wasm32"), wasm_bindgen_test)]
+    #[cfg_attr(not(target_arch = "wasm32"), test)]
     #[cfg(feature = "korean")]
     fn from_language_code_ko() {
         assert_eq!(
@@ -348,7 +367,8 @@ mod test {
         );
     }
 
-    #[test]
+    #[cfg_attr(all(target_arch = "wasm32"), wasm_bindgen_test)]
+    #[cfg_attr(not(target_arch = "wasm32"), test)]
     #[cfg(feature = "spanish")]
     fn from_language_code_es() {
         assert_eq!(
@@ -357,7 +377,8 @@ mod test {
         );
     }
 
-    #[test]
+    #[cfg_attr(all(target_arch = "wasm32"), wasm_bindgen_test)]
+    #[cfg_attr(not(target_arch = "wasm32"), test)]
     fn from_invalid_language_code() {
         assert_eq!(Language::from_language_code("not a real language"), None);
     }

--- a/src/mnemonic.rs
+++ b/src/mnemonic.rs
@@ -313,8 +313,11 @@ impl From<Mnemonic> for String {
 #[cfg(test)]
 mod test {
     use super::*;
+    #[cfg(target_arch = "wasm32")]
+    use wasm_bindgen_test::*;
 
-    #[test]
+    #[cfg_attr(all(target_arch = "wasm32"), wasm_bindgen_test)]
+    #[cfg_attr(not(target_arch = "wasm32"), test)]
     fn back_to_back() {
         let m1 = Mnemonic::new(MnemonicType::Words12, Language::English);
         let m2 = Mnemonic::from_phrase(m1.phrase(), Language::English).unwrap();
@@ -326,7 +329,8 @@ mod test {
         assert_eq!(m1.phrase(), m3.phrase(), "Phrase must be the same");
     }
 
-    #[test]
+    #[cfg_attr(all(target_arch = "wasm32"), wasm_bindgen_test)]
+    #[cfg_attr(not(target_arch = "wasm32"), test)]
     fn mnemonic_from_entropy() {
         let entropy = &[
             0x33, 0xE4, 0x6B, 0xB1, 0x3A, 0x74, 0x6E, 0xA4, 0x1C, 0xDD, 0xE4, 0x5C, 0x90, 0x84,
@@ -339,7 +343,8 @@ mod test {
         assert_eq!(phrase, mnemonic.phrase());
     }
 
-    #[test]
+    #[cfg_attr(all(target_arch = "wasm32"), wasm_bindgen_test)]
+    #[cfg_attr(not(target_arch = "wasm32"), test)]
     fn mnemonic_from_phrase() {
         let entropy = &[
             0x33, 0xE4, 0x6B, 0xB1, 0x3A, 0x74, 0x6E, 0xA4, 0x1C, 0xDD, 0xE4, 0x5C, 0x90, 0x84,
@@ -352,14 +357,16 @@ mod test {
         assert_eq!(entropy, mnemonic.entropy());
     }
 
-    #[test]
+    #[cfg_attr(all(target_arch = "wasm32"), wasm_bindgen_test)]
+    #[cfg_attr(not(target_arch = "wasm32"), test)]
     fn mnemonic_format() {
         let mnemonic = Mnemonic::new(MnemonicType::Words15, Language::English);
 
         assert_eq!(mnemonic.phrase(), format!("{}", mnemonic));
     }
 
-    #[test]
+    #[cfg_attr(all(target_arch = "wasm32"), wasm_bindgen_test)]
+    #[cfg_attr(not(target_arch = "wasm32"), test)]
     fn mnemonic_hex_format() {
         let entropy = &[
             0x03, 0xE4, 0x6B, 0xB1, 0x3A, 0x74, 0x6E, 0xA4, 0x1C, 0xDD, 0xE4, 0x5C, 0x90, 0x84,

--- a/src/mnemonic_type.rs
+++ b/src/mnemonic_type.rs
@@ -202,8 +202,11 @@ impl fmt::Display for MnemonicType {
 #[cfg(test)]
 mod test {
     use super::*;
+    #[cfg(target_arch = "wasm32")]
+    use wasm_bindgen_test::*;
 
-    #[test]
+    #[cfg_attr(all(target_arch = "wasm32"), wasm_bindgen_test)]
+    #[cfg_attr(not(target_arch = "wasm32"), test)]
     fn word_count() {
         assert_eq!(MnemonicType::Words12.word_count(), 12);
         assert_eq!(MnemonicType::Words15.word_count(), 15);
@@ -212,7 +215,8 @@ mod test {
         assert_eq!(MnemonicType::Words24.word_count(), 24);
     }
 
-    #[test]
+    #[cfg_attr(all(target_arch = "wasm32"), wasm_bindgen_test)]
+    #[cfg_attr(not(target_arch = "wasm32"), test)]
     fn entropy_bits() {
         assert_eq!(MnemonicType::Words12.entropy_bits(), 128);
         assert_eq!(MnemonicType::Words15.entropy_bits(), 160);
@@ -221,7 +225,8 @@ mod test {
         assert_eq!(MnemonicType::Words24.entropy_bits(), 256);
     }
 
-    #[test]
+    #[cfg_attr(all(target_arch = "wasm32"), wasm_bindgen_test)]
+    #[cfg_attr(not(target_arch = "wasm32"), test)]
     fn checksum_bits() {
         assert_eq!(MnemonicType::Words12.checksum_bits(), 4);
         assert_eq!(MnemonicType::Words15.checksum_bits(), 5);

--- a/src/seed.rs
+++ b/src/seed.rs
@@ -88,8 +88,11 @@ impl fmt::UpperHex for Seed {
 mod test {
     use super::*;
     use crate::language::Language;
+    #[cfg(target_arch = "wasm32")]
+    use wasm_bindgen_test::*;
 
-    #[test]
+    #[cfg_attr(all(target_arch = "wasm32"), wasm_bindgen_test)]
+    #[cfg_attr(not(target_arch = "wasm32"), test)]
     fn seed_hex_format() {
         let entropy = &[
             0x33, 0xE4, 0x6B, 0xB1, 0x3A, 0x74, 0x6E, 0xA4, 0x1C, 0xDD, 0xE4, 0x5C, 0x90, 0x84,
@@ -111,7 +114,8 @@ mod test {
         assert_eq!(format!("{:x}", seed), expected_seed_hex);
     }
 
-    #[test]
+    #[cfg_attr(all(target_arch = "wasm32"), wasm_bindgen_test)]
+    #[cfg_attr(not(target_arch = "wasm32"), test)]
     /// Test vector is derived from https://github.com/infincia/bip39-rs/issues/26#issuecomment-586476647
     #[cfg(feature = "spanish")]
     fn issue_26() {
@@ -123,7 +127,8 @@ mod test {
         );
     }
 
-    #[test]
+    #[cfg_attr(all(target_arch = "wasm32"), wasm_bindgen_test)]
+    #[cfg_attr(not(target_arch = "wasm32"), test)]
     /// https://github.com/MetacoSA/NBitcoin/blob/master/NBitcoin.Tests/data/bip39_vectors.en.json
     fn password_is_unicode_normalized() {
         test_unicode_normalization(
@@ -134,7 +139,8 @@ mod test {
         );
     }
 
-    #[test]
+    #[cfg_attr(all(target_arch = "wasm32"), wasm_bindgen_test)]
+    #[cfg_attr(not(target_arch = "wasm32"), test)]
     /// https://github.com/bip32JP/bip32JP.github.io/commit/360c05a6439e5c461bbe5e84c7567ec38eb4ac5f
     #[cfg(feature = "japanese")]
     fn japanese_normalization_1() {
@@ -146,7 +152,8 @@ mod test {
         );
     }
 
-    #[test]
+    #[cfg_attr(all(target_arch = "wasm32"), wasm_bindgen_test)]
+    #[cfg_attr(not(target_arch = "wasm32"), test)]
     #[cfg(feature = "japanese")]
     fn japanese_normalization_2() {
         test_unicode_normalization(
@@ -157,7 +164,8 @@ mod test {
         );
     }
 
-    #[test]
+    #[cfg_attr(all(target_arch = "wasm32"), wasm_bindgen_test)]
+    #[cfg_attr(not(target_arch = "wasm32"), test)]
     #[cfg(feature = "french")]
     fn french_normalization() {
         test_unicode_normalization(

--- a/tests/generate.rs
+++ b/tests/generate.rs
@@ -1,6 +1,6 @@
-extern crate bip39;
-
 use bip39::{Language, Mnemonic, MnemonicType, Seed};
+#[cfg(target_arch = "wasm32")]
+use wasm_bindgen_test::*;
 
 fn test_word_count(expected_word_count: usize) {
     let mnemonic_type = MnemonicType::for_word_count(expected_word_count).unwrap();
@@ -17,37 +17,41 @@ fn test_word_count(expected_word_count: usize) {
     assert!(seed_bytes.len() == 64);
 }
 
-#[test]
-fn generate_12_english() {
+macro_rules! test_maybe_wasm {
+    ($name:ident, $body:expr) => {
+        #[cfg_attr(all(target_arch = "wasm32"), wasm_bindgen_test)]
+        #[cfg_attr(not(target_arch = "wasm32"), test)]
+        fn $name() {
+            $body
+        }
+    }
+}
+
+test_maybe_wasm!(generate_12_english, {
     test_word_count(12);
-}
+});
 
-#[test]
-fn generate_15_english() {
+test_maybe_wasm!(generate_15_english, {
     test_word_count(15);
-}
+});
 
-#[test]
-fn generate_18_english() {
+test_maybe_wasm!(generate_18_english, {
     test_word_count(18);
-}
+});
 
-#[test]
-fn generate_21_english() {
+test_maybe_wasm!(generate_21_english, {
     test_word_count(21);
-}
+});
 
-#[test]
-fn generate_24_english() {
+test_maybe_wasm!(generate_24_english, {
     test_word_count(24);
-}
+});
 
-#[test]
-fn generate_from_invalid_entropy() {
+test_maybe_wasm!(generate_from_invalid_entropy, {
     // 15 bytes
     let entropy = &[
         0x33, 0xE4, 0x6B, 0xB1, 0x3A, 0x74, 0x6E, 0xA4, 0x1C, 0xDD, 0xE4, 0x5C, 0x90, 0x84, 0x6A,
     ];
 
     assert!(Mnemonic::from_entropy(entropy, Language::English).is_err());
-}
+});

--- a/tests/standard-vectors.rs
+++ b/tests/standard-vectors.rs
@@ -1,6 +1,3 @@
-extern crate bip39;
-extern crate hex;
-
 use bip39::{Language, Mnemonic, Seed};
 
 fn test_mnemonic(entropy_hex: &str, expected_phrase: &str) {
@@ -32,7 +29,10 @@ fn test_seed(phrase: &str, password: &str, expected_seed_hex: &str) {
 macro_rules! tests {
     ($([$entropy_hex:expr, $phrase:expr, $seed_hex:expr, $xprv:expr]),*) => {
         mod mnemonic_tests {
-            #[test]
+            #[cfg(target_arch = "wasm32")]
+            use wasm_bindgen_test::*;
+            #[cfg_attr(all(target_arch = "wasm32"), wasm_bindgen_test)]
+            #[cfg_attr(not(target_arch = "wasm32"), test)]
             fn test_all() {
                 $(
                     super::test_mnemonic($entropy_hex, $phrase);
@@ -41,7 +41,10 @@ macro_rules! tests {
         }
 
         mod seed_tests {
-            #[test]
+            #[cfg(target_arch = "wasm32")]
+            use wasm_bindgen_test::*;
+            #[cfg_attr(all(target_arch = "wasm32"), wasm_bindgen_test)]
+            #[cfg_attr(not(target_arch = "wasm32"), test)]
             fn test_all() {
                 $(
                     super::test_seed($phrase, "TREZOR", $seed_hex);

--- a/tests/validate.rs
+++ b/tests/validate.rs
@@ -1,6 +1,6 @@
-extern crate bip39;
-
 use bip39::{Language, Mnemonic, MnemonicType};
+#[cfg(target_arch = "wasm32")]
+use wasm_bindgen_test::*;
 
 fn validate_language(lang: Language) {
     let types = &[
@@ -21,15 +21,31 @@ fn validate_language(lang: Language) {
     }
 }
 
-#[test]
-fn validate_12_english() {
+macro_rules! test_maybe_wasm {
+    ($name:ident, $(#[$attr:meta])+, $body:expr) => {
+        #[cfg_attr(all(target_arch = "wasm32"), wasm_bindgen_test)]
+        #[cfg_attr(not(target_arch = "wasm32"), test)]
+        $(#[$attr])*
+        fn $name() {
+            $body
+        }
+    };
+    ($name:ident, $body:expr) => {
+        #[cfg_attr(all(target_arch = "wasm32"), wasm_bindgen_test)]
+        #[cfg_attr(not(target_arch = "wasm32"), test)]
+        fn $name() {
+            $body
+        }
+    };
+}
+
+test_maybe_wasm!(validate_12_english, {
     let phrase = "park remain person kitchen mule spell knee armed position rail grid ankle";
 
     let _ = Mnemonic::from_phrase(phrase, Language::English).expect("Can create a Mnemonic");
-}
+});
 
-#[test]
-fn validate_12_english_extra_spaces() {
+test_maybe_wasm!(validate_12_english_extra_spaces, {
     let phrase = " park remain  person kitchen mule spell knee armed position rail grid ankle ";
     let clean_phrase = "park remain person kitchen mule spell knee armed position rail grid ankle";
 
@@ -38,93 +54,67 @@ fn validate_12_english_extra_spaces() {
         Mnemonic::from_phrase(clean_phrase, Language::English).expect("Can create a Mnemonic");
 
     assert_eq!(mnemonic.entropy(), clean_mnemonic.entropy());
-}
+});
 
-#[test]
-fn validate_15_english() {
+test_maybe_wasm!(validate_15_english, {
     let phrase = "any paddle cabbage armor atom satoshi fiction night wisdom nasty they midnight chicken play phone";
 
     let _ = Mnemonic::from_phrase(phrase, Language::English).expect("Can create a Mnemonic");
-}
+});
 
-#[test]
-fn validate_18_english() {
+test_maybe_wasm!(validate_18_english, {
     let phrase = "soda oak spy claim best oppose gun ghost school use sign shock sign pipe vote follow category filter";
 
     let _ = Mnemonic::from_phrase(phrase, Language::English).expect("Can create a Mnemonic");
-}
+});
 
-#[test]
-fn validate_21_english() {
+test_maybe_wasm!(validate_21_english, {
     let phrase = "quality useless orient offer pole host amazing title only clog sight wild anxiety gloom market rescue fan language entry fan oyster";
 
     let _ = Mnemonic::from_phrase(phrase, Language::English).expect("Can create a Mnemonic");
-}
+});
 
-#[test]
-fn validate_24_english() {
+test_maybe_wasm!(validate_24_english, {
     let phrase = "always guess retreat devote warm poem giraffe thought prize ready maple daughter girl feel clay silent lemon bracket abstract basket toe tiny sword world";
 
     let _ = Mnemonic::from_phrase(phrase, Language::English).expect("Can create a Mnemonic");
-}
+});
 
-#[test]
-fn validate_12_english_uppercase() {
+test_maybe_wasm!(validate_12_english_uppercase, {
     let invalid_phrase =
         "Park remain person kitchen mule spell knee armed position rail grid ankle";
 
     assert!(Mnemonic::from_phrase(invalid_phrase, Language::English).is_err());
-}
+});
 
-#[test]
-fn validate_english() {
+test_maybe_wasm!(validate_english, {
     validate_language(Language::English);
-}
+});
 
-#[test]
-#[cfg(feature = "chinese-simplified")]
-
-fn validate_chinese_simplified() {
+test_maybe_wasm!(validate_chinese_simplified, #[cfg(feature = "chinese-simplified")], {
     validate_language(Language::ChineseSimplified);
-}
+});
 
-#[test]
-#[cfg(feature = "chinese-traditional")]
-
-fn validate_chinese_traditional() {
+test_maybe_wasm!(validate_chinese_traditional, #[cfg(feature = "chinese-traditional")], {
     validate_language(Language::ChineseTraditional);
-}
+});
 
-#[test]
-#[cfg(feature = "french")]
-
-fn validate_french() {
+test_maybe_wasm!(validate_french, #[cfg(feature = "french")], {
     validate_language(Language::French);
-}
+});
 
-#[test]
-#[cfg(feature = "italian")]
-fn validate_italian() {
+test_maybe_wasm!(validate_italian, #[cfg(feature = "italian")], {
     validate_language(Language::Italian);
-}
+});
 
-#[test]
-#[cfg(feature = "japanese")]
-
-fn validate_japanese() {
+test_maybe_wasm!(validate_japanese, #[cfg(feature = "japanese")], {
     validate_language(Language::Japanese);
-}
+});
 
-#[test]
-#[cfg(feature = "korean")]
-
-fn validate_korean() {
+test_maybe_wasm!(validate_korean, #[cfg(feature = "korean")], {
     validate_language(Language::Korean);
-}
+});
 
-#[test]
-#[cfg(feature = "spanish")]
-
-fn validate_spanish() {
+test_maybe_wasm!(validate_spanish, #[cfg(feature = "spanish")], {
     validate_language(Language::Spanish);
-}
+});


### PR DESCRIPTION
This PR will supersede #32 if preferred.

This PR proposes the following changes:
1. Enable proper WASM flags in the dependencies
2. *Remove* `parking_lot` feature flag from `once_cell`, as suggested by its author `matklad`. In summary, recent `once_cell` has adapted to better work with `std` mutexes. See the discussion [here](https://www.reddit.com/r/rust/comments/pwcltx/comment/heh5ont/?utm_source=share&utm_medium=web2x&context=3)
3. Adapt the tests to run with `wasm-pack` by conditionally using `wasm-bindgen-test`