### PR TITLE
Update dependencies to latest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,19 +31,19 @@ spanish = []
 default = ["chinese-simplified", "chinese-traditional", "french", "italian", "japanese", "korean", "spanish"]
 
 [dependencies]
-anyhow = "1.0"
-thiserror = "1.0"
-rustc-hash = "1.1"
-sha2 = "0.10"
-hmac = "0.12"
-pbkdf2 = { version = "0.10", default-features = false }
-rand = "0.8"
-once_cell = { version = "1.9" }
-unicode-normalization = "0.1"
-zeroize = { version = "1.5", features = ["zeroize_derive"] }
+anyhow = "1.0.55"
+thiserror = "1.0.30"
+rustc-hash = "1.1.0"
+sha2 = "0.10.2"
+hmac = "0.12.1"
+pbkdf2 = { version = "0.10.1", default-features = false }
+rand = "0.8.5"
+once_cell = { version = "1.9.0" }
+unicode-normalization = "0.1.19"
+zeroize = { version = "1.5.3", features = ["zeroize_derive"] }
 
 [dev-dependencies]
-hex = "0.4"
+hex = "0.4.3"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,19 +31,19 @@ spanish = []
 default = ["chinese-simplified", "chinese-traditional", "french", "italian", "japanese", "korean", "spanish"]
 
 [dependencies]
-anyhow = "1.0.55"
-thiserror = "1.0.30"
-rustc-hash = "1.1.0"
-sha2 = "0.10.2"
-hmac = "0.12.1"
-pbkdf2 = { version = "0.10.1", default-features = false }
-rand = "0.8.5"
-once_cell = { version = "1.9.0" }
-unicode-normalization = "0.1.19"
-zeroize = { version = "1.5.3", features = ["zeroize_derive"] }
+anyhow = "1.0"
+thiserror = "1.0"
+rustc-hash = "1.1"
+sha2 = "0.10"
+hmac = "0.12"
+pbkdf2 = { version = "0.10", default-features = false }
+rand = "0.8"
+once_cell = { version = "1.9" }
+unicode-normalization = "0.1"
+zeroize = { version = "1.5", features = ["zeroize_derive"] }
 
 [dev-dependencies]
-hex = "0.4.3"
+hex = "0.4"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tiny-bip39"
-version = "0.8.2"
+version = "0.9.0-pre.0"
 authors = [
     "Stephen Oliver <steve@infincia.com>",
     "Maciej Hirsz <hello@maciej.codes>",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,26 +31,22 @@ spanish = []
 default = ["chinese-simplified", "chinese-traditional", "french", "italian", "japanese", "korean", "spanish"]
 
 [dependencies]
-anyhow = "1.0.34"
-thiserror = "1.0.22"
+anyhow = "1.0.55"
+thiserror = "1.0.30"
 rustc-hash = "1.1.0"
-sha2 = "0.9.1"
-hmac = "0.8.1"
-pbkdf2 = { version = "0.4.0", default-features = false }
-rand = "0.7.3"
-once_cell = { version = "1.8.0" }
-unicode-normalization = "0.1.13"
-zeroize = { version = "1.1.1", features = ["zeroize_derive"] }
+sha2 = "0.10.2"
+hmac = "0.12.1"
+pbkdf2 = { version = "0.10.1", default-features = false }
+rand = "0.8.5"
+once_cell = { version = "1.9.0" }
+unicode-normalization = "0.1.19"
+zeroize = { version = "1.5.3", features = ["zeroize_derive"] }
 
 [dev-dependencies]
-hex = "0.4.2"
+hex = "0.4.3"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen = "0.2"
-
-[target.'cfg(target_arch = "wasm32")'.dependencies.rand]
-version = "0.7.3"
-features = ["wasm-bindgen"]
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 wasm-bindgen-test = "0.3"


### PR DESCRIPTION
I verified tests pass. With that said, `rand 0.8.0` removed the `wasm-bindgen` support, so I removed that dep, and I'm not sure how to test it.