### PR TITLE
Zeroize intermediate strings allocated during seed construction

### DIFF
--- a/src/seed.rs
+++ b/src/seed.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 use unicode_normalization::UnicodeNormalization;
-use zeroize::Zeroize;
+use zeroize::{Zeroize, Zeroizing};
 use crate::crypto::pbkdf2;
 use crate::mnemonic::Mnemonic;
 
@@ -31,8 +31,8 @@ impl Seed {
     ///
     /// [Mnemonic]: ./mnemonic/struct.Mnemonic.html
     pub fn new(mnemonic: &Mnemonic, password: &str) -> Self {
-        let salt = format!("mnemonic{}", password);
-        let normalized_salt = salt.nfkd().to_string();
+        let salt = Zeroizing::new(format!("mnemonic{}", password));
+        let normalized_salt = Zeroizing::new(salt.nfkd().to_string());
         let bytes = pbkdf2(mnemonic.phrase().as_bytes(), &normalized_salt);
 
         Self { bytes }


### PR DESCRIPTION
The password provided for seed construction may leak through two temporary `String` objects allocated on the heap, referenced by variables `salt` and `normalized_salt`. In order to prevent leaking, the strings should be zeroized on drop.
