### PR TITLE
pbkdf2 0.12

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,8 +36,7 @@ anyhow = "1.0.57"
 thiserror = "1.0.31"
 rustc-hash = "1.1.0"
 sha2 = "0.10.2"
-hmac = "0.12.1"
-pbkdf2 = { version = "0.11.0", default-features = false }
+pbkdf2 = { version = "0.12.0", default-features = false, features = ["hmac"] }
 rand = { version = "0.8.5", optional = true }
 once_cell = "1.12.0"
 unicode-normalization = "0.1.19"

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -5,7 +5,6 @@
 //! [Seed]: ../seed/struct.Seed.html
 //!
 
-use hmac::Hmac;
 #[cfg(feature = "rand")]
 use rand::{thread_rng, RngCore};
 use sha2::Digest;
@@ -38,7 +37,7 @@ pub(crate) fn gen_random_bytes(byte_length: usize) -> Vec<u8> {
 pub(crate) fn pbkdf2(input: &[u8], salt: &str) -> Vec<u8> {
     let mut seed = vec![0u8; PBKDF2_BYTES];
 
-    pbkdf2::pbkdf2::<Hmac<sha2::Sha512>>(input, salt.as_bytes(), PBKDF2_ROUNDS, &mut seed);
+    pbkdf2::pbkdf2_hmac::<sha2::Sha512>(input, salt.as_bytes(), PBKDF2_ROUNDS, &mut seed);
 
     seed
 }


### PR DESCRIPTION
Moves from pbkdf2() to pbkdf2_hmac() as the former now returns a Result, and I didn't want to introduce an unwrap/change the API.