### PR TITLE
Add word index to invalid word error

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -5,8 +5,8 @@ use thiserror::Error;
 pub enum ErrorKind {
     #[error("invalid checksum")]
     InvalidChecksum,
-    #[error("invalid word in phrase")]
-    InvalidWord,
+    #[error("invalid word in phrase with index {0}")]
+    InvalidWord(usize),
     #[error("invalid keysize: {0}")]
     InvalidKeysize(usize),
     #[error("invalid number of words in phrase: {0}")]

--- a/src/language.rs
+++ b/src/language.rs
@@ -1,4 +1,3 @@
-use crate::error::ErrorKind;
 use crate::util::{Bits, Bits11};
 use rustc_hash::FxHashMap;
 
@@ -11,11 +10,8 @@ pub struct WordList {
 }
 
 impl WordMap {
-    pub fn get_bits(&self, word: &str) -> Result<Bits11, ErrorKind> {
-        match self.inner.get(word) {
-            Some(n) => Ok(*n),
-            None => Err(ErrorKind::InvalidWord)?,
-        }
+    pub fn get_bits(&self, word: &str) -> Option<Bits11> {
+        self.inner.get(word).cloned()
     }
 }
 

--- a/src/mnemonic.rs
+++ b/src/mnemonic.rs
@@ -196,8 +196,9 @@ impl Mnemonic {
         // Preallocate enough space for the longest possible word list
         let mut bits = BitWriter::with_capacity(264);
 
-        for word in phrase.split(" ") {
-            bits.push(wordmap.get_bits(&word)?);
+        for (idx, word) in phrase.split(' ').enumerate() {
+            let word_bits = wordmap.get_bits(word).ok_or(ErrorKind::InvalidWord(idx))?;
+            bits.push(word_bits);
         }
 
         let mtype = MnemonicType::for_word_count(bits.len() / 11)?;


### PR DESCRIPTION
Invalid word error changed to contain an index of the invalid word in the user mnemonic.