### PR TITLE
security: RUSTSEC-2026-0097: Bump rand to 0.10.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ thiserror = "1.0.31"
 rustc-hash = "1.1.0"
 sha2 = "0.10.2"
 pbkdf2 = { version = "0.12.0", default-features = false, features = ["hmac"] }
-rand = { version = "0.8.5", optional = true }
+rand = { version = "0.10.1", optional = true }
 once_cell = "1.12.0"
 unicode-normalization = "0.1.19"
 zeroize = { version = "1.5.5", features = ["zeroize_derive"] }

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -6,7 +6,7 @@
 //!
 
 #[cfg(feature = "rand")]
-use rand::{thread_rng, RngCore};
+use rand::{rand_core::UnwrapErr, rngs::SysRng, Rng};
 use sha2::Digest;
 
 const PBKDF2_ROUNDS: u32 = 2048;
@@ -22,7 +22,7 @@ pub(crate) fn sha256_first_byte(input: &[u8]) -> u8 {
 ///
 #[cfg(feature = "rand")]
 pub(crate) fn gen_random_bytes(byte_length: usize) -> Vec<u8> {
-    let mut rng = thread_rng();
+    let mut rng = UnwrapErr(SysRng);
     let mut bytes = vec![0u8; byte_length];
 
     rng.fill_bytes(&mut bytes);


### PR DESCRIPTION
https://rustsec.org/advisories/RUSTSEC-2026-0097

Replace thread_rng() + RngCore::fill_bytes with UnwrapErr(SysRng) and Rng::fill_bytes so entropy still comes from the OS RNG without using the legacy thread-local API.